### PR TITLE
feat(claude,codex): add extra_args option for passing custom CLI flags

### DIFF
--- a/src/adapters/claude/mod.rs
+++ b/src/adapters/claude/mod.rs
@@ -185,6 +185,12 @@ fn build_args(opts: &RunOptions) -> Vec<String> {
         args.push("--dangerously-skip-permissions".into());
     }
 
+    // User-supplied flags last, so callers can override earlier defaults
+    // (e.g. force `--output-format text` or pass `--json-schema <schema>`).
+    if let Some(extra) = claude_opts.and_then(|c| c.extra_args.as_ref()) {
+        args.extend(extra.iter().cloned());
+    }
+
     args
 }
 
@@ -360,5 +366,74 @@ mod tests {
             .position(|a| a == "--setting-sources")
             .expect("flag emitted");
         assert_eq!(args[idx + 1], "project,local");
+    }
+
+    #[test]
+    fn build_args_extra_args_omitted_by_default() {
+        let opts = RunOptions {
+            task: "hello".into(),
+            ..Default::default()
+        };
+        let args = build_args(&opts);
+        // Nothing about extra_args should appear when the option is unset.
+        assert!(!args.iter().any(|a| a == "--json-schema"));
+    }
+
+    #[test]
+    fn build_args_extra_args_appended_verbatim() {
+        let opts = RunOptions {
+            task: "hello".into(),
+            providers: Some(crate::types::ProviderOptions {
+                claude: Some(crate::types::ClaudeOptions {
+                    extra_args: Some(vec!["--json-schema".into(), "{\"type\":\"object\"}".into()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let args = build_args(&opts);
+        let idx = args
+            .iter()
+            .position(|a| a == "--json-schema")
+            .expect("extra_args flag emitted");
+        // Adjacent, in order — `args.extend` preserves both.
+        assert_eq!(args[idx + 1], "{\"type\":\"object\"}");
+    }
+
+    #[test]
+    fn build_args_extra_args_come_after_crate_defaults() {
+        // Callers should be able to override what this crate emits — e.g.
+        // re-pin `--output-format` to `text` even though we default to
+        // stream-json. That only works if user-supplied flags land last.
+        let opts = RunOptions {
+            task: "hello".into(),
+            skip_permissions: true,
+            providers: Some(crate::types::ProviderOptions {
+                claude: Some(crate::types::ClaudeOptions {
+                    extra_args: Some(vec!["--output-format".into(), "text".into()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let args = build_args(&opts);
+        // The crate emits `--output-format stream-json` early; the user
+        // override must appear strictly after the permission-bypass block
+        // (the last thing the crate emits).
+        let user_idx = args
+            .iter()
+            .rposition(|a| a == "--output-format")
+            .expect("user --output-format emitted");
+        let bypass_idx = args
+            .iter()
+            .position(|a| a == "--dangerously-skip-permissions")
+            .expect("skip_permissions flag emitted");
+        assert!(
+            user_idx > bypass_idx,
+            "user extra_args must be appended last so they win over crate defaults"
+        );
+        assert_eq!(args[user_idx + 1], "text");
     }
 }

--- a/src/adapters/codex/mod.rs
+++ b/src/adapters/codex/mod.rs
@@ -156,6 +156,11 @@ fn build_args(opts: &RunOptions) -> Vec<String> {
         args.push("--skip-git-repo-check".into());
     }
 
+    // User-supplied flags last, so callers can override earlier defaults.
+    if let Some(extra) = codex_opts.and_then(|c| c.extra_args.as_ref()) {
+        args.extend(extra.iter().cloned());
+    }
+
     args
 }
 
@@ -587,5 +592,69 @@ foo = "bar"
         let content = std::fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("File prompt content"));
         assert!(!content.contains("Inline prompt"));
+    }
+
+    #[test]
+    fn build_args_extra_args_omitted_by_default() {
+        let opts = RunOptions {
+            task: "hello".into(),
+            ..Default::default()
+        };
+        let args = build_args(&opts);
+        assert!(!args.iter().any(|a| a == "--proto"));
+    }
+
+    #[test]
+    fn build_args_extra_args_appended_verbatim() {
+        let opts = RunOptions {
+            task: "hello".into(),
+            providers: Some(crate::types::ProviderOptions {
+                codex: Some(crate::types::CodexOptions {
+                    extra_args: Some(vec!["--proto".into(), "json".into()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let args = build_args(&opts);
+        let idx = args
+            .iter()
+            .position(|a| a == "--proto")
+            .expect("extra_args flag emitted");
+        assert_eq!(args[idx + 1], "json");
+    }
+
+    #[test]
+    fn build_args_extra_args_come_after_crate_defaults() {
+        // Callers should be able to override what this crate emits — same
+        // contract as the Claude adapter. User-supplied flags land last.
+        let opts = RunOptions {
+            task: "hello".into(),
+            skip_permissions: true,
+            providers: Some(crate::types::ProviderOptions {
+                codex: Some(crate::types::CodexOptions {
+                    extra_args: Some(vec!["--skip-git-repo-check".into()]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let args = build_args(&opts);
+        // The crate emits --skip-git-repo-check once for skip_permissions,
+        // then the user's extra copy. The user copy must be strictly later.
+        let positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter_map(|(i, a)| (a == "--skip-git-repo-check").then_some(i))
+            .collect();
+        assert_eq!(
+            positions.len(),
+            2,
+            "both crate-emitted and user-supplied copies expected, got {args:?}"
+        );
+        // Last occurrence is the user-supplied one.
+        assert!(positions[1] > positions[0]);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,6 +97,13 @@ pub struct ClaudeOptions {
     /// `None` = let the CLI default (loads user/project/local).
     /// `Some(vec![])` = load nothing — silences global SessionStart hooks.
     pub setting_sources: Option<Vec<SettingSource>>,
+    /// Extra arguments appended verbatim to the Claude CLI invocation.
+    ///
+    /// Useful for flags this crate does not model explicitly — for example
+    /// `--json-schema <schema>` to force structured output, or
+    /// `--input-format text`. Order is preserved; entries are appended after
+    /// all flags this crate emits, so they can override earlier defaults.
+    pub extra_args: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -107,6 +114,12 @@ pub struct CodexOptions {
     pub additional_directories: Option<Vec<String>>,
     pub images: Option<Vec<String>>,
     pub output_schema: Option<String>,
+    /// Extra arguments appended verbatim to the Codex CLI invocation.
+    ///
+    /// Same semantics as the Claude / Gemini equivalents — pass any flags
+    /// this crate doesn't model. Appended last, so they can override earlier
+    /// defaults.
+    pub extra_args: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

`GeminiOptions` already exposes an `extra_args: Option<Vec<String>>` hook that lets callers pass arbitrary flags the crate does not model. This PR mirrors that field on `ClaudeOptions` and `CodexOptions` so the same escape hatch is available everywhere.

## Motivation

Downstream consumers want to forward flags that this crate doesn't expose explicitly. Concrete example: [`tuist/blick`](https://github.com/tuist/blick) drives Claude with `max_turns: 1` and a system-prompt instruction to return JSON. Sonnet 4.5 sometimes emits a conversational preamble (`I'll review the diff...`) and then runs out of turn before producing the JSON body, breaking blick's parser. The fix is `claude --json-schema <schema>` (the CLI then forces structured output and the preamble is impossible by construction) — but there is no way to pass that flag through `cli-agents` today.

`extra_args` is the simplest, lowest-blast-radius escape hatch:

- Already proven on `GeminiOptions`.
- No coupling to specific flags — future Claude / Codex flags don't require a new release of this crate to be usable.
- `None` is a no-op, so it's fully backwards-compatible.

## Semantics

Matching the existing Gemini behavior:

| Property | Behavior |
|---|---|
| Default (`None`) | No flags emitted. Identical to today. |
| Position in arg vector | **Last**, after every flag this crate emits. Callers can therefore override crate defaults (e.g. re-pin \`--output-format\` from \`stream-json\` to \`text\`). |
| Internal order | Preserved (`args.extend`). |

A dedicated test (\`build_args_extra_args_come_after_crate_defaults\`) pins the override-ordering contract on both adapters, so future refactors of \`build_args\` can't silently break it.

## Tests

- \`build_args_extra_args_omitted_by_default\` — no \`extra_args\` ⇒ no flags emitted.
- \`build_args_extra_args_appended_verbatim\` — flag-value pairs appear adjacently in the right order.
- \`build_args_extra_args_come_after_crate_defaults\` — pins the ordering contract that makes overrides work.

All six (3 × Claude + 3 × Codex) pass alongside the existing 73 tests.

\`\`\`
$ cargo test
test result: ok. 79 passed; 0 failed; 0 ignored
\`\`\`

## Out of scope

- Pre-existing \`cargo fmt --check\` failures on \`main\` (the \`use crate::DEFAULT_MAX_OUTPUT_BYTES\` ordering across all three adapter files, dating to ~1 month ago per CI history). I touched none of those lines so my files don't introduce new fmt diffs, but they also don't fix the existing ones — happy to open a follow-up fmt-only PR if useful.
- Pre-existing clippy warning in \`runner/emit.rs:170\` (type complexity). Same disposition.

## Why this PR matters for blick

After this lands and a release ships, the blick adapter (\`src/agent/via_cli_agents.rs\`) can be one line richer:

\`\`\`rust
claude: Some(ClaudeOptions {
    max_turns: Some(1),
    extra_args: config.args.clone().into_iter().filter(|s| !s.is_empty()).collect::<Vec<_>>().into(),
    ..ClaudeOptions::default()
}),
\`\`\`

…and \`blick.toml\` users can write \`agent.args = [\"--json-schema\", \"{...}\"]\` to force structured output, which fully solves the JSON-parsing failure mode described above. I'll open the matching blick PR once a release is cut.