### PR TITLE
style: apply rustfmt and fix clippy lints

### DIFF
--- a/src/adapters/claude/mod.rs
+++ b/src/adapters/claude/mod.rs
@@ -1,11 +1,11 @@
 mod parse;
 
+use crate::DEFAULT_MAX_OUTPUT_BYTES;
 use crate::adapters::CliAdapter;
 use crate::discovery::discover_binary;
 use crate::error::{Error, Result};
 use crate::events::StreamEvent;
 use crate::types::{CliName, RunOptions, RunResult};
-use crate::DEFAULT_MAX_OUTPUT_BYTES;
 use std::collections::HashMap;
 use tokio_util::sync::CancellationToken;
 

--- a/src/adapters/codex/mod.rs
+++ b/src/adapters/codex/mod.rs
@@ -1,11 +1,11 @@
 mod parse;
 
+use crate::DEFAULT_MAX_OUTPUT_BYTES;
 use crate::adapters::CliAdapter;
 use crate::discovery::discover_binary;
 use crate::error::{Error, Result};
 use crate::events::StreamEvent;
 use crate::types::{CliName, RunOptions, RunResult};
-use crate::DEFAULT_MAX_OUTPUT_BYTES;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -524,7 +524,10 @@ foo = "bar"
         );
         // mcp_servers replaced wholesale — pre-existing entries are dropped
         // in favor of the caller-supplied set, which is the documented behavior.
-        let mcp = merged.get("mcp_servers").and_then(|v| v.as_table()).unwrap();
+        let mcp = merged
+            .get("mcp_servers")
+            .and_then(|v| v.as_table())
+            .unwrap();
         assert!(mcp.contains_key("test"));
         assert!(!mcp.contains_key("preexisting"));
     }
@@ -562,7 +565,13 @@ foo = "bar"
         assert!(auth.exists());
         assert!(auth.symlink_metadata().unwrap().file_type().is_symlink());
         let sessions = dst.path().join("sessions");
-        assert!(sessions.symlink_metadata().unwrap().file_type().is_symlink());
+        assert!(
+            sessions
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
         // Reading through the symlink reaches the original file.
         let contents =
             std::fs::read_to_string(dst.path().join("sessions").join("a.jsonl")).unwrap();

--- a/src/adapters/gemini/mod.rs
+++ b/src/adapters/gemini/mod.rs
@@ -1,11 +1,11 @@
 mod parse;
 
+use crate::DEFAULT_MAX_OUTPUT_BYTES;
 use crate::adapters::CliAdapter;
 use crate::discovery::discover_binary;
 use crate::error::{Error, Result};
 use crate::events::StreamEvent;
 use crate::types::{CliName, McpServer, RunOptions, RunResult};
-use crate::DEFAULT_MAX_OUTPUT_BYTES;
 use std::collections::HashMap;
 use tokio_util::sync::CancellationToken;
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -225,7 +225,7 @@ pub(crate) fn extract_error_message(stderr: Option<&str>) -> Option<String> {
                 || lower.contains("denied")
                 || lower.contains("unauthorized")
         })
-        .or_else(|| stderr.lines().filter(|l| !l.is_empty()).last());
+        .or_else(|| stderr.lines().rfind(|l| !l.is_empty()));
     msg.map(|s| s.trim().to_string())
 }
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -239,7 +239,7 @@ mod tests {
 
         // Sorting: newer versions should come first
         let mut versions = vec!["v18.17.1", "v22.0.0", "v20.11.0"];
-        versions.sort_by(|a, b| parse_ver(b).cmp(&parse_ver(a)));
+        versions.sort_by_key(|v| std::cmp::Reverse(parse_ver(v)));
         assert_eq!(versions, vec!["v22.0.0", "v20.11.0", "v18.17.1"]);
     }
 

--- a/src/runner/emit.rs
+++ b/src/runner/emit.rs
@@ -167,10 +167,12 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    fn event_collector() -> (
+    type EventCollector = (
         Arc<dyn Fn(StreamEvent) + Send + Sync>,
         Arc<Mutex<Vec<StreamEvent>>>,
-    ) {
+    );
+
+    fn event_collector() -> EventCollector {
         let events = Arc::new(Mutex::new(Vec::new()));
         let events_clone = events.clone();
         let cb: Arc<dyn Fn(StreamEvent) + Send + Sync> = Arc::new(move |e: StreamEvent| {


### PR DESCRIPTION
Clears the toolchain-update drift that has been failing the lint job on main:

- `cargo fmt`: newer rustfmt changed import-ordering rules (3 files, mechanical)
- clippy: `rfind` instead of `filter().last()` in stderr extraction, `sort_by_key(Reverse(..))` in a discovery test, and a type alias for the test event-collector tuple

Verified locally: `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, and all 79 tests pass.